### PR TITLE
[gen_summary] script simplification

### DIFF
--- a/gen_summary.sh
+++ b/gen_summary.sh
@@ -3,9 +3,9 @@
 PGKSTORE=packages
 DOWNFILE=00_download.txt
 
-find "$PGKSTORE" -name "$DOWNFILE" -exec cat "{}" ";" | \
+find "$PGKSTORE" -name "$DOWNFILE" -exec cat "{}" "+" | \
 grep -v -E '^#|^$' | \
-sort -u | sort -k 2 > all_downloads.txt
+sort -u -k 2 > all_downloads.txt
 
 
 


### PR DESCRIPTION
"+" at the end of -exec reduces number of cat invocations. It executes
one cat with multiple files as a parameter instead.

One 'sort' is enough.